### PR TITLE
promptUserSelectResource now trims "\r" carriage return character from console input

### DIFF
--- a/trello_options.go
+++ b/trello_options.go
@@ -122,6 +122,7 @@ func promptUserSelectResource() int {
 	}
 
 	i = strings.TrimRight(i, "\n")
+	i = strings.TrimRight(i, "\r")
 	id, err := strconv.Atoi(i)
 	if err != nil {
 		log.Fatal("Hmm... did you type a number from the list ?")


### PR DESCRIPTION
This PR fixes an issue I was having with the executable not correctly parsing my number inputs on Windows 8.1 using git bash. Same result when using cmd.exe.

```
gp $ ./trello_to_clubhouse_windows_x64.exe
Would you like to migrate all attachments from trello cards?
This will entail downloading the attachments and uploading to dropbox
A dropbox account will be required for the token
[0] Yes
[1] No
1
2017/03/13 11:22:05 Hmm... did you type a number from the list ?
```

The error causing this behavior was:
```
strconv.Atoi: parsing "1\r": invalid syntax
```

Windows unfortunately still uses the carriage return in their newline character ("\r\n").